### PR TITLE
Fix for when filtering is disabled on the client.

### DIFF
--- a/DataTablesDotNet/ModelBinding/DataTablesModelBinder.cs
+++ b/DataTablesDotNet/ModelBinding/DataTablesModelBinder.cs
@@ -19,7 +19,12 @@ namespace DataTablesDotNet.ModelBinding {
                     var value = property.GetValue(model, null);
                     if (property.PropertyType.IsInterface == false) {
                         var formValue = requestParams.Get(property.Name);
-                        property.SetValue(model, Convert.ChangeType(formValue, property.PropertyType), null);
+                        // if filtering is disabled, the sSearch and bRegex parameters will not be sent from the client.  So, we check to make sure we have a value before
+                        // trying to set it in the model.
+                        if (formValue != null)
+                        {
+                            property.SetValue(model, Convert.ChangeType(formValue, property.PropertyType), null);
+                        }
                     }
                 }
 


### PR DESCRIPTION
When filtering is disabled on the client data table, the sSearch and bRegex parameters are not sent in the query string.  I added a check for this so the model binder code doesn't throw an exception.
